### PR TITLE
Update esogu.cls

### DIFF
--- a/esogu.cls
+++ b/esogu.cls
@@ -47,7 +47,7 @@
 %----------Dili Türkçe ve fontu ayarlamak için---------------
 \usepackage{polyglossia}			
 \setmainlanguage{turkish}
-
+\PolyglossiaSetup{turkish}{indentfirst=true}
 \usepackage{fontspec}
 \setmainfont[Language=Turkish]{Times New Roman}		%Times new roman için
 %----------------------------------------------------


### PR DESCRIPTION
Bölümden sonra ilk paragrafı polyglossia dil paketi varsayılan olarak boşluksuz yerleştiriyor.
Bu durumu aşmak için indent first özelliğini aktif etmek gerekiyor. Aksi takdirde başlıklardan sonraki ilk paragraflarda boşluk olmuyor.
Şablona eklenen bu parametre de işe yaramıyor. (\@afterindenttrue)
Bu sebeple aşağıdaki kod eklendi.
\PolyglossiaSetup{turkish}{indentfirst=true}